### PR TITLE
tissot: Set proper permissions for proc/touchpanel

### DIFF
--- a/rootdir/init.qcom.sh
+++ b/rootdir/init.qcom.sh
@@ -427,6 +427,9 @@ case "$target" in
         ;;
 esac
 
+# Set shared touchpanel nodes ownership (these are proc_symlinks to the real sysfs nodes)
+chown -LR system.system /proc/touchpanel
+
 #
 # Copy qcril.db if needed for RIL
 #


### PR DESCRIPTION
Set shared touchpanel nodes ownership (these are proc_symlinks to the real sysfs nodes)